### PR TITLE
Integration crashing on startup when items in the list does not have SourceId

### DIFF
--- a/custom_components/ica_shopping_list/__init__.py
+++ b/custom_components/ica_shopping_list/__init__.py
@@ -314,11 +314,11 @@ class ShoppingData():
                 return
 
             _LOGGER.debug("Adding to ica: " + str(api_data))
-            for row in api_data["Rows"]:
-                name = row["ProductName"].capitalize()
-                uuid = row["OfflineId"]
-                complete = row["IsStrikedOver"]
-                source = row["SourceId"]
+            for row in api_data.get("Rows", []):
+                name = row.get("ProductName", "").capitalize()
+                uuid = row.get("OfflineId", "")
+                complete = row.get("IsStrikedOver", False)
+                source = row.get("SourceId", "")  # Handle the case when 'SourceId' is missing
 
                 item = {"name": name, "id": uuid, "complete": complete, "SourceId": source}
                 _LOGGER.debug("Item: " + str(item))


### PR DESCRIPTION
From Home Assistant start up log:

```
Logger: homeassistant.setup
Source: setup.py:288
First occurred: 15 October 2023 at 15:49:34 (1 occurrences)
Last logged: 15 October 2023 at 15:49:34

Error during setup of component ica_shopping_list
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/setup.py", line 288, in _async_setup_component
    result = await task
             ^^^^^^^^^^
  File "/config/custom_components/ica_shopping_list/__init__.py", line 129, in async_setup
    await data.async_load()
  File "/config/custom_components/ica_shopping_list/__init__.py", line 330, in async_load
    self.items = await self.hass.async_add_job(load)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/ica_shopping_list/__init__.py", line 321, in load
    source = row["SourceId"]
             ~~~^^^^^^^^^^^^
KeyError: 'SourceId'
```

From API (postman)
```
 "Rows": [
                {
                    "Id": 557866342,
                    "ProductName": "Lätta",
                    "IsStrikedOver": false,
                    "Recipes": [],
                    "InternalOrder": -2,
                    "LatestChange": "2023-10-14T05:05:16Z",
                    "OfflineId": "E1F48674-1AD2-4AF9-A08D-7576909975CC"
                },
                {
                    "Id": 557866343,
                    "ProductName": "aluminiumfolie",
                    "SourceId": 10085,
                    "IsStrikedOver": false,
                    "Recipes": [],
                    "InternalOrder": -1,
                    "ArticleGroupId": 9,
                    "ArticleGroupIdExtended": 21,
                    "LatestChange": "2023-10-14T05:05:12Z",
                    "OfflineId": "D67391E4-11AE-4F41-9C85-9AB09988ED08"
                },
```